### PR TITLE
Bugfix: error pages paths

### DIFF
--- a/tasks/setup_nginx.yml
+++ b/tasks/setup_nginx.yml
@@ -19,14 +19,14 @@
 
 - name: Create the maintenance page
   template: src=maintenance.html
-            dest="{{ wsgi_storage_dir }}{{ wsgi_project_name }}maintenance.html"
+            dest="{{ wsgi_storage_dir }}{{ wsgi_project_name }}/maintenance.html"
             mode=0664
   notify:
     - restart nginx
 
 - name: Create the 500 error page
   template: src=500.html
-            dest="{{ wsgi_storage_dir }}{{ wsgi_project_name }}500.html"
+            dest="{{ wsgi_storage_dir }}{{ wsgi_project_name }}/500.html"
             mode=0664
   notify:
     - restart nginx


### PR DESCRIPTION
This was creating error pages like: `/mnt/my_project500.html`.

It should be `/mnt/my_project/500.html` instead.