### PR TITLE
Add env vars to cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ an example is as follows:
         frequency:
             minute: "*/5"
         logfile: "/dev/null"
+        environment:
+            MY_ENV_VAR: 'MY_VALUE'
+            MY_ENV_VAR_2: 'MY_VALUE_2'
 
-All of your environmental variables are made available to the process running
-the cron, the command will look something like this:
+Providing additional environment variables by the ``environment`` argument is
+optional. Note that all of your environmental variables are made available to
+the process running the cron, the command will look something like this:
 
     /bin/bash -c "source ~/.bash_profile && {{ command }} &>> {{ logfile }}
 

--- a/tasks/setup_cron_tasks.yml
+++ b/tasks/setup_cron_tasks.yml
@@ -2,20 +2,18 @@
 
 - name: Cron | Setup App cron tasks
   cron:
-      name: "App cron task {{ item.name }}"
-      user: "{{ item.user }}"
-      day: "{{ item.frequency.day | default('*') }}"
-      hour: "{{ item.frequency.hour | default('*') }}"
-      minute: "{{ item.frequency.minute | default('*') }}"
-      month: "{{ item.frequency.month | default('*') }}"
-      weekday: "{{ item.frequency.weekday | default('*') }}"
-      job:
-           source ~/.bash_profile &&
-           {{
-              ('export ' + item.environment | attr('iteritems')() | map('join', '=') | join('; export ') + ' &&')
-              if item.environment | default({})
-              else ''
-           }}
-           {{ item.command }}
-           &>> {{ item.logfile }}
+    name: "App cron task {{ item.name }}"
+    user: "{{ item.user }}"
+    day: "{{ item.frequency.day | default('*') }}"
+    hour: "{{ item.frequency.hour | default('*') }}"
+    minute: "{{ item.frequency.minute | default('*') }}"
+    month: "{{ item.frequency.month | default('*') }}"
+    weekday: "{{ item.frequency.weekday | default('*') }}"
+    job:
+      source ~/.bash_profile &&
+      {% for variable in (item.environment|default({})).iteritems() %}
+        export {{ variable[0] }}="{{ variable[1] }}" &&
+      {%- endfor %}
+      {{ item.command }}
+      &>> {{ item.logfile }}
   with_items: wsgi_cron_tasks

--- a/tasks/setup_cron_tasks.yml
+++ b/tasks/setup_cron_tasks.yml
@@ -1,12 +1,21 @@
 ---
 
 - name: Cron | Setup App cron tasks
-  cron: name="App cron task {{ item.name }}"
-        user={{ item.user }}
-        day={{ item.frequency.day | default('*') }}
-        hour={{ item.frequency.hour | default('*') }}
-        minute={{ item.frequency.minute | default('*') }}
-        month={{ item.frequency.month | default('*') }}
-        weekday={{ item.frequency.weekday | default('*') }}
-        job="/bin/bash -c \"source ~/.bash_profile && {{ item.command }} &>> {{ item.logfile }}\""
+  cron:
+      name: "App cron task {{ item.name }}"
+      user: "{{ item.user }}"
+      day: "{{ item.frequency.day | default('*') }}"
+      hour: "{{ item.frequency.hour | default('*') }}"
+      minute: "{{ item.frequency.minute | default('*') }}"
+      month: "{{ item.frequency.month | default('*') }}"
+      weekday: "{{ item.frequency.weekday | default('*') }}"
+      job:
+           source ~/.bash_profile &&
+           {{
+              ('export ' + item.environment | attr('iteritems')() | map('join', '=') | join('; export ') + ' &&')
+              if item.environment | default({})
+              else ''
+           }}
+           {{ item.command }}
+           &>> {{ item.logfile }}
   with_items: wsgi_cron_tasks


### PR DESCRIPTION
Allow the ``wsgi_cron_tasks`` to define a set of custom environment variables, which are loaded after loading the bash profile.