### PR TITLE
Raise startsecs, to avoid kind-of-rapidly cycling

### DIFF
--- a/templates/supervisor_config.j2
+++ b/templates/supervisor_config.j2
@@ -2,3 +2,4 @@
 command = {{ wsgi_virtualenv }}bin/gunicorn_start
 user = {{ wsgi_gunicorn_user }}
 stdout_errfile = {{ wsgi_log_dir }}supervisor.log
+startsecs = 5


### PR DESCRIPTION
startsecs=1 by default, so if a process takes more than a second to figure out it can't run
(eg because the system is under high load) then supervisord will never enter backoff
for that process, and will keep on trying to re-launch over and over again.

This causes particular problems on virtualised systems, where there's a risk with a high
run queue (even with low processor usage) of having a steal profile applied, reducing
the utility of the virtual host.