### PR TITLE
Set X-Forwarded-Proto header in vhost conf

### DIFF
--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -45,6 +45,7 @@ server {
         }
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
         proxy_redirect off;
 


### PR DESCRIPTION
This should be set in conjunction with the following Django setting:

    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')