### PR TITLE
Allow to set a request line limit for Gunicorn

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ wsgi_gunicorn_user: '{{ wsgi_project_name }}'
 wsgi_gunicorn_group: '{{ wsgi_project_name }}'
 wsgi_gunicorn_num_workers: 5
 wsgi_gunicorn_max_requests: 0
+wsgi_request_line_limit: 8192
 
 # Nginx
 wsgi_server_names: []

--- a/templates/gunicorn_start.j2
+++ b/templates/gunicorn_start.j2
@@ -36,4 +36,5 @@ exec gunicorn {{ wsgi_wsgi_path }} \
         --log-level=critical \
         --log-file={{ wsgi_log_dir }}{{ wsgi_project_name }}.log \
         --pid={{ wsgi_virtualenv }}bin/{{ wsgi_project_name }}.pid \
+        --limit-request-line={{ wsgi_request_line_limit }} \
         --bind=unix:$SOCKFILE &>> {{ wsgi_log_dir }}{{ wsgi_project_name }}.log


### PR DESCRIPTION
This allows to avoid errors that look like:

```
Bad Request
Request Line is too large (5090 > 4094)
```