### PR TITLE
Add in logrotate script, and ensure var loading tasks are always run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   when: vars_file is defined
   tags:
     - env_vars
+    - always
 
 - name: Check if a project has been deployed
   stat: path='{{ wsgi_path }}current'
@@ -12,6 +13,7 @@
   changed_when: false
   tags:
     - env_vars
+    - always
 
 - include: setup_system.yml
 

--- a/tasks/setup_system.yml
+++ b/tasks/setup_system.yml
@@ -27,3 +27,10 @@
   apt: name={{ item }} update_cache={{ wsgi_update_apt_cache }} force=yes
        state=installed
   with_items: wsgi_extra_apt_packages
+
+- name: Create the log rotation script
+  template: src=logrotate.j2
+            dest="/etc/logrotate.d/{{ wsgi_project_name }}"
+            mode=0644 owner=root group=root
+  tags:
+    - logs

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,0 +1,15 @@
+{{ wsgi_log_dir }}*.log {
+    su {{ wsgi_gunicorn_user }} {{ wsgi_gunicorn_group }}
+    daily
+    missingok
+    rotate 14
+    compress
+    dateext
+    notifempty
+    create 0640 {{ wsgi_gunicorn_user }} {{ wsgi_gunicorn_group }}
+    prerotate
+        if [ -f {{ wsgi_virtualenv }}bin/{{ wsgi_project_name }}.pid ]; then
+            kill -USR1 $(cat {{ wsgi_virtualenv }}bin/{{ wsgi_project_name }}.pid )
+        fi
+    endscript
+}


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/12392

- Add logrotate.d script for rotating the logs every day, and compressing them
- ensure that tasks that load in vital variables are always run